### PR TITLE
feat: `delete -> deleteSubscription`, implement `deletePushMessage`

### DIFF
--- a/packages/push-client/src/dappClient.ts
+++ b/packages/push-client/src/dappClient.ts
@@ -109,9 +109,11 @@ export class DappClient extends IDappClient {
     }
   };
 
-  public delete: IDappClient["delete"] = async (params) => {
+  public deleteSubscription: IDappClient["deleteSubscription"] = async (
+    params
+  ) => {
     try {
-      return await this.engine.delete(params);
+      return await this.engine.deleteSubscription(params);
     } catch (error: any) {
       this.logger.error(error.message);
       throw error;

--- a/packages/push-client/src/types/baseClient.ts
+++ b/packages/push-client/src/types/baseClient.ts
@@ -80,6 +80,12 @@ export declare namespace PushClientTypes {
     icon: string;
     url: string;
   }
+
+  interface PushMessageRecord {
+    id: number;
+    topic: string;
+    message: PushMessage;
+  }
 }
 
 export abstract class IBaseClient {
@@ -103,7 +109,7 @@ export abstract class IBaseClient {
   // ---------- Public Methods (common) ----------------------------------------------- //
 
   public abstract getActiveSubscriptions: IPushEngine["getActiveSubscriptions"];
-  public abstract delete: IPushEngine["delete"];
+  public abstract deleteSubscription: IPushEngine["deleteSubscription"];
 
   // ---------- Event Handlers ----------------------------------------------- //
 

--- a/packages/push-client/src/types/engine.ts
+++ b/packages/push-client/src/types/engine.ts
@@ -60,7 +60,9 @@ export abstract class IPushEngine {
   // get all messages for a subscription
   public abstract getMessageHistory(params: {
     topic: string;
-  }): Record<number, PushClientTypes.PushMessage>;
+  }): Record<number, PushClientTypes.PushMessageRecord>;
+
+  public abstract deletePushMessage(params: { id: number }): void;
 
   // ---------- Public Methods (common) --------------------------------- //
 
@@ -71,7 +73,7 @@ export abstract class IPushEngine {
   >;
 
   // delete active subscription
-  public abstract delete(params: { topic: string }): Promise<void>;
+  public abstract deleteSubscription(params: { topic: string }): Promise<void>;
 
   // ---------- Protected Helpers --------------------------------------- //
 

--- a/packages/push-client/src/types/walletClient.ts
+++ b/packages/push-client/src/types/walletClient.ts
@@ -5,7 +5,10 @@ import { IBaseClient, PushClientTypes } from "./baseClient";
 export abstract class IWalletClient extends IBaseClient {
   public abstract messages: IStore<
     string,
-    { topic: string; messages: Record<number, PushClientTypes.PushMessage> }
+    {
+      topic: string;
+      messages: Record<number, PushClientTypes.PushMessageRecord>;
+    }
   >;
 
   constructor(public opts: PushClientTypes.WalletClientOptions) {
@@ -18,4 +21,5 @@ export abstract class IWalletClient extends IBaseClient {
   public abstract reject: IPushEngine["reject"];
   public abstract decryptMessage: IPushEngine["decryptMessage"];
   public abstract getMessageHistory: IPushEngine["getMessageHistory"];
+  public abstract deletePushMessage: IPushEngine["deletePushMessage"];
 }

--- a/packages/push-client/src/walletClient.ts
+++ b/packages/push-client/src/walletClient.ts
@@ -119,6 +119,15 @@ export class WalletClient extends IWalletClient {
     }
   };
 
+  public deletePushMessage: IWalletClient["deletePushMessage"] = (params) => {
+    try {
+      return this.engine.deletePushMessage(params);
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  };
+
   public getActiveSubscriptions: IWalletClient["getActiveSubscriptions"] =
     () => {
       try {
@@ -129,9 +138,11 @@ export class WalletClient extends IWalletClient {
       }
     };
 
-  public delete: IWalletClient["delete"] = async (params) => {
+  public deleteSubscription: IWalletClient["deleteSubscription"] = async (
+    params
+  ) => {
     try {
-      return await this.engine.delete(params);
+      return await this.engine.deleteSubscription(params);
     } catch (error: any) {
       this.logger.error(error.message);
       throw error;


### PR DESCRIPTION
## Context

- Aligning with: https://github.com/WalletConnect/walletconnect-docs/pull/483
- Renames `BaseClient.delete -> BaseClient.deleteSubscription`
- Implements `WalletClient.deletePushMessage`
- Adds integration tests