### PR TITLE
Reduced sync messages

### DIFF
--- a/packages/push-client/src/utils/history.ts
+++ b/packages/push-client/src/utils/history.ts
@@ -1,5 +1,66 @@
-import { HistoryClient } from "@walletconnect/history";
+import {
+  HistoricalMessages,
+  HistoryClient,
+  Message,
+} from "@walletconnect/history";
+import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
 import { ICore } from "@walletconnect/types";
+
+// Only inject necessary messages
+// Primarily to reduce sync messages
+export const reduceAndInjectHistory = async (
+  core: ICore,
+  messageArr: Message[],
+  topic: string
+) => {
+  // payload id, Message
+  const messages = new Map<number, Message>();
+  // Sync store key, [Sync Request, Encoded Message]
+  // We maintain the encoded message to avoid re-encoding later to reduce time complexity
+  const syncMessages = new Map<string, [JsonRpcRequest<any>, Message]>();
+  for (let i = 0; i < messageArr.length; ++i) {
+    const message = messageArr[i];
+    const decoded = await core.crypto.decode(message.topic, message.message);
+
+    // No need to inject messages existing in relayer
+    if (core.relayer.messages.has(message.topic, message.message)) {
+      continue;
+    }
+
+    // Non sync messages do not need to be diffed
+    if (!("params" in decoded) || !decoded.method.includes("wc_sync")) {
+      messages.set(decoded.id, message);
+      continue;
+    }
+
+    // From this point forward, all messages handled are sync messages
+    if (syncMessages.has(decoded.params.key)) {
+      const current = syncMessages.get(decoded.params.key)!;
+
+      // Only the most recent syncSet or sync delete is relevant.
+      if (current[0].id < decoded.id) {
+        syncMessages.set(decoded.params.key, [decoded, message]);
+      }
+    } else {
+      syncMessages.set(decoded.params.key, [decoded, message]);
+    }
+  }
+
+  // Flushing sync messages into the general message map for injection
+  for (const [syncDecodedMessage, syncMessage] of syncMessages.values()) {
+    messages.set(syncDecodedMessage.id, syncMessage);
+  }
+  syncMessages.clear();
+
+  const reducedHistoricalMessages = new HistoricalMessages(core, {
+    direction: "backward",
+    messages: Array.from(messages.values()),
+    nextId: 0,
+    topic: topic,
+  });
+
+  await reducedHistoricalMessages.injectIntoRelayer();
+};
 
 export const fetchAndInjectHistory = async (
   topic: string,
@@ -8,17 +69,20 @@ export const fetchAndInjectHistory = async (
   historyClient: HistoryClient
 ) => {
   try {
+    console.log("1te getting messages");
     const messages = await historyClient.getMessages({
       topic,
       direction: "backward",
       messageCount: 200,
     });
+    console.log("1te got messages", messages);
 
     core.logger.info(
       `Fetched ${messages.messageResponse.messages.length} messages from history`
     );
 
-    await messages.injectIntoRelayer();
+    const currentMessages = messages.messageResponse.messages;
+    await reduceAndInjectHistory(core, currentMessages, topic);
   } catch (e: any) {
     throw new Error(
       `Failed to fetch and inject history for ${name}: ${e.message}`

--- a/packages/push-client/src/utils/history.ts
+++ b/packages/push-client/src/utils/history.ts
@@ -69,13 +69,11 @@ export const fetchAndInjectHistory = async (
   historyClient: HistoryClient
 ) => {
   try {
-    console.log("1te getting messages");
     const messages = await historyClient.getMessages({
       topic,
       direction: "backward",
       messageCount: 200,
     });
-    console.log("1te got messages", messages);
 
     core.logger.info(
       `Fetched ${messages.messageResponse.messages.length} messages from history`

--- a/packages/push-client/src/walletClient.ts
+++ b/packages/push-client/src/walletClient.ts
@@ -323,7 +323,6 @@ export class WalletClient extends IWalletClient {
         account,
         signature,
       } of this.syncClient.signatures.getAll()) {
-        console.log("1te Initting for", account);
         this.initSyncStores({ account, signature });
       }
 

--- a/packages/push-client/src/walletClient.ts
+++ b/packages/push-client/src/walletClient.ts
@@ -234,7 +234,6 @@ export class WalletClient extends IWalletClient {
     account,
     signature,
   }) => {
-    console.log("1TE Init sync stores");
     this.subscriptions = new this.SyncStoreController(
       "com.walletconnect.notify.pushSubscription",
       this.syncClient,
@@ -279,12 +278,6 @@ export class WalletClient extends IWalletClient {
         historyFetchedStores.includes(store.key) && store.account === account
       );
     });
-
-    console.log(
-      "1TE fetching history",
-      account,
-      stores.map((store) => store.account)
-    );
 
     stores.forEach((store) => {
       fetchAndInjectHistory(


### PR DESCRIPTION
# Changes
- Remove redundant changes
- Clean up sync messages to avoid getting duplicate subscriptions on the same topic
- The issue stemmed from the fact that message injection is event based and the order can't be guaranteed. Therefore, the way to avoid faulty state is to only inject recent/relevant messages.