### PR TITLE
Use dapp identity key with aud, per spec

### DIFF
--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -215,22 +215,22 @@ export class NotifyClient extends INotifyClient {
       account,
       signature,
       (subTopic, subscription) => {
-        // if (!subscription) {
-        //   // Unsubscribe only if currently subscribed
-        //   if (this.core.relayer.subscriber.topics.includes(subTopic)) {
-        //     this.core.relayer.subscriber.unsubscribe(subTopic);
-        //   }
-        //   // Delete messages since subscription was removed
-        //   this.messages.delete(subTopic, {
-        //     code: -1,
-        //     message: "Deleted parent subscription",
-        //   });
+        if (!subscription) {
+          // Unsubscribe only if currently subscribed
+          if (this.core.relayer.subscriber.topics.includes(subTopic)) {
+            this.core.relayer.subscriber.unsubscribe(subTopic);
+          }
+          // Delete messages since subscription was removed
+          this.messages.delete(subTopic, {
+            code: -1,
+            message: "Deleted parent subscription",
+          });
 
-        //   // Delete symkey since subscription was removed
-        //   this.core.crypto.deleteSymKey(subTopic);
+          // Delete symkey since subscription was removed
+          this.core.crypto.deleteSymKey(subTopic);
 
-        //   return;
-        // }
+          return;
+        }
 
         if (subscription) {
           const existingSubExists =

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -232,18 +232,16 @@ export class NotifyClient extends INotifyClient {
           return;
         }
 
-        if (subscription) {
-          const existingSubExists =
-            this.messages.getAll({ topic: subTopic }).length > 0;
-          if (existingSubExists) return;
+        const existingSubExists =
+          this.messages.getAll({ topic: subTopic }).length > 0;
+        if (existingSubExists) return;
 
-          this.messages.set(subTopic, { topic: subTopic, messages: [] });
-          this.core.crypto.setSymKey(subscription.symKey, subTopic).then(() => {
-            if (!this.core.relayer.subscriber.topics.includes(subTopic)) {
-              this.core.relayer.subscriber.subscribe(subTopic);
-            }
-          });
-        }
+        this.messages.set(subTopic, { topic: subTopic, messages: [] });
+        this.core.crypto.setSymKey(subscription.symKey, subTopic).then(() => {
+          if (!this.core.relayer.subscriber.topics.includes(subTopic)) {
+            this.core.relayer.subscriber.subscribe(subTopic);
+          }
+        });
       }
     );
     await this.subscriptions.init();

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1028,7 +1028,7 @@ export class NotifyEngine extends INotifyEngine {
     });
   };
 
-  private resolveDappPublicKey = async (
+  private resolveDappKeys = async (
     dappUrl: string
   ): Promise<{ dappPublicKey: string; dappIdentityKey: string }> => {
     let didDoc: NotifyClientTypes.NotifyDidDocument;

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -124,13 +124,6 @@ export class NotifyEngine extends INotifyEngine {
       app: metadata.url,
     };
 
-    console.log(
-      "DECODED JWT",
-      payload,
-      "Decoded ed25519 identity key:",
-      identityKeyPub
-    );
-
     this.client.logger.info(
       `[Notify] subscribe > generating subscriptionAuth JWT for payload: ${JSON.stringify(
         payload
@@ -438,8 +431,6 @@ export class NotifyEngine extends INotifyEngine {
         const { topic, message, publishedAt } = event;
 
         const payload = await this.client.core.crypto.decode(topic, message);
-
-        console.log("Decoded: ", payload);
 
         if (isJsonRpcRequest(payload)) {
           this.client.core.history.set(topic, payload);

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -82,7 +82,7 @@ export class NotifyEngine extends INotifyEngine {
   }) => {
     this.isInitialized();
 
-    const { dappPublicKey, dappIdentityKey } = await this.resolveDappPublicKey(
+    const { dappPublicKey, dappIdentityKey } = await this.resolveDappKeys(
       metadata.url
     );
     const notifyConfig = await this.resolveNotifyConfig(metadata.url);
@@ -436,15 +436,6 @@ export class NotifyEngine extends INotifyEngine {
       RELAYER_EVENTS.message,
       async (event: RelayerTypes.MessageEvent) => {
         const { topic, message, publishedAt } = event;
-
-        console.log(
-          "Got message: ",
-          message,
-          "Topic: ",
-          topic,
-          "Published at:",
-          publishedAt
-        );
 
         const payload = await this.client.core.crypto.decode(topic, message);
 
@@ -873,7 +864,7 @@ export class NotifyEngine extends INotifyEngine {
       const identityKeyPub = await this.client.identityKeys.getIdentity({
         account: subscription.account,
       });
-      const { dappIdentityKey } = await this.resolveDappPublicKey(
+      const { dappIdentityKey } = await this.resolveDappKeys(
         subscription.metadata.url
       );
       const issuedAt = Math.round(Date.now() / 1000);
@@ -916,7 +907,7 @@ export class NotifyEngine extends INotifyEngine {
       const identityKeyPub = await this.client.identityKeys.getIdentity({
         account: subscription.account,
       });
-      const { dappIdentityKey } = await this.resolveDappPublicKey(
+      const { dappIdentityKey } = await this.resolveDappKeys(
         subscription.metadata.url
       );
       const issuedAt = Math.round(Date.now() / 1000);
@@ -958,7 +949,7 @@ export class NotifyEngine extends INotifyEngine {
       const identityKeyPub = await this.client.identityKeys.getIdentity({
         account: subscription.account,
       });
-      const { dappIdentityKey } = await this.resolveDappPublicKey(
+      const { dappIdentityKey } = await this.resolveDappKeys(
         subscription.metadata.url
       );
       const issuedAt = Math.round(Date.now() / 1000);


### PR DESCRIPTION
Per spec: https://specs.walletconnect.com/2.0/specs/clients/notify/notify-authentication#notify-subscription

We were using dapp url as `aud` in all JWTs, when it should be dapp identity key. 

The reason this worked so far is because the `aud` field was not validated yet