### PR TITLE
Use iat instead of published at

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -584,7 +584,7 @@ export class NotifyEngine extends INotifyEngine {
     };
 
   protected onNotifyMessageRequest: INotifyEngine["onNotifyMessageRequest"] =
-    async (topic, payload, publishedAt) => {
+    async (topic, payload) => {
       this.client.logger.info({
         event: "Engine.onNotifyMessageRequest",
         topic,
@@ -615,7 +615,9 @@ export class NotifyEngine extends INotifyEngine {
             id: payload.id,
             topic,
             message: messageClaims.msg,
-            publishedAt,
+            // Not using publishedAt as these messages can be coming from Archive API
+            // Multiplying by 1000 to get the timestamp in ms, instead of seconds
+            publishedAt: messageClaims.iat * 1000,
           },
         },
       });


### PR DESCRIPTION
# Changes
- Use `iat` (Issued at) instead of `publishedAt` for setting messages
- Multiply `iat` by `1000` to get the time in milliseconds 
# Testing
- [x] Unit tests pass
- [x] Symlinked against Web3Inbox
    - [x] New messages have correct timestamp
    - [x] After running `localStorage.clear()` and fetching the messages through history, we get the correct timestamp instead of `"Now"`. 