### PR TITLE
Fix history message injection

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -607,7 +607,16 @@ export class NotifyEngine extends INotifyEngine {
         return;
       }
 
+      // To account for data races occuring from history injection of notify messages
+      if (!this.client.messages.keys.some((key) => key === topic)) {
+        await this.client.messages.set(topic, {
+          messages: {},
+          topic,
+        });
+      }
+
       const currentMessages = this.client.messages.get(topic).messages;
+
       await this.client.messages.update(topic, {
         messages: {
           ...currentMessages,


### PR DESCRIPTION
# Description
- On notify message:
  - If there is no store for passed topic, create the store for passed topic

# Why?
The way history injection works is completely event based. This means in some edge cases, the event for `notify_message` may be fired before `notify_subscription`. This causes the engine to try and `update` a `messages` store that does not exist.

```ts
stores.forEach((store) => {
  fetchAndInjectHistory(
    store.topic,
    store.key,
    this.core,
    this.historyClient
  )
    .catch((e) => this.logger.error(e.message))
    .then(() => {
      this.subscriptions.getAll().forEach(({ topic, metadata }) => {
        fetchAndInjectHistory(
          topic,
          metadata.name,
          this.core,
          this.historyClient
        );
      });
    });
});

```